### PR TITLE
Adjustments to key storage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,74 +1,74 @@
 {
-    "name": "rich2k/laravel-weatherkit",
-    "type": "library",
-    "description": "Provides a Wrapper for the Apple WeatherKit API",
-    "keywords": [
-        "rich2k",
-        "laravel-weatherkit",
-        "weatherkit",
-        "apple weatherkit",
-        "weatherkit api",
-        "apple weatherkit api",
-        "weather",
-        "forecast",
-        "weather forecast"
-    ],
-    "homepage": "https://github.com/rich2k/laravel-weatherkit",
-    "support": {
-        "issues": "https://github.com/rich2k/laravel-weatherkit/issues",
-        "source": "https://github.com/rich2k/laravel-weatherkit"
-    },
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Richard Hyland",
-            "email": "rhyland@gmail.com",
-            "homepage": "https://github.com/rich2k/laravel-weatherkit",
-            "role": "Developer"
-        }
-    ],
-    "require": {
-        "php": ">=7.4.0",
-        "ext-json": "*",
-        "ext-openssl": "*",
-        "firebase/php-jwt": "~5.5|^6.3",
-        "guzzlehttp/guzzle": "~7.0",
-        "illuminate/support": "~7.0|~8.0|~9.0",
-        "nesbot/carbon": "~1.0|~2.0"
-    },
-    "require-dev": {
-        "phpunit/phpunit" : "4.*"
-    },
-    "autoload": {
-        "psr-4": {
-            "Rich2k\\LaravelWeatherKit\\": "src"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Rich2k\\LaravelWeatherKit\\": "tests"
-        }
-    },
-    "scripts": {
-        "test": "phpunit",
-        "check-style": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",
-        "fix-style": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests"
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Rich2k\\LaravelWeatherKit\\Providers\\LaravelServiceProvider",
-                "Rich2k\\LaravelWeatherKit\\Providers\\CollectionsServiceProvider"
-            ],
-            "aliases": {
-                "WeatherKit": "Rich2k\\LaravelWeatherKit\\Facades\\WeatherKit"
-            }
-        }
-    },
-    "prefer-stable": true,
-    "config": {
-        "optimize-autoloader": true,
-        "preferred-install": "dist",
-        "sort-packages": true
+  "name": "mobiadroit/laravel-weatherkit",
+  "type": "library",
+  "description": "Provides a Wrapper for the Apple WeatherKit API",
+  "keywords": [
+    "rich2k",
+    "laravel-weatherkit",
+    "weatherkit",
+    "apple weatherkit",
+    "weatherkit api",
+    "apple weatherkit api",
+    "weather",
+    "forecast",
+    "weather forecast"
+  ],
+  "homepage": "https://github.com/rich2k/laravel-weatherkit",
+  "support": {
+    "issues": "https://github.com/rich2k/laravel-weatherkit/issues",
+    "source": "https://github.com/rich2k/laravel-weatherkit"
+  },
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Richard Hyland",
+      "email": "rhyland@gmail.com",
+      "homepage": "https://github.com/rich2k/laravel-weatherkit",
+      "role": "Developer"
     }
+  ],
+  "require": {
+    "php": ">=7.4.0",
+    "ext-json": "*",
+    "ext-openssl": "*",
+    "firebase/php-jwt": "~5.5|^6.3",
+    "guzzlehttp/guzzle": "~7.0",
+    "illuminate/support": "~7.0|~8.0|~9.0",
+    "nesbot/carbon": "~1.0|~2.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "4.*"
+  },
+  "autoload": {
+    "psr-4": {
+      "Rich2k\\LaravelWeatherKit\\": "src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Rich2k\\LaravelWeatherKit\\": "tests"
+    }
+  },
+  "scripts": {
+    "test": "phpunit",
+    "check-style": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",
+    "fix-style": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests"
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Rich2k\\LaravelWeatherKit\\Providers\\LaravelServiceProvider",
+        "Rich2k\\LaravelWeatherKit\\Providers\\CollectionsServiceProvider"
+      ],
+      "aliases": {
+        "WeatherKit": "Rich2k\\LaravelWeatherKit\\Facades\\WeatherKit"
+      }
+    }
+  },
+  "prefer-stable": true,
+  "config": {
+    "optimize-autoloader": true,
+    "preferred-install": "dist",
+    "sort-packages": true
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "mobiadroit/laravel-weatherkit",
+  "name": "rich2k/laravel-weatherkit",
   "type": "library",
   "description": "Provides a Wrapper for the Apple WeatherKit API",
   "keywords": [

--- a/config/weatherkit.php
+++ b/config/weatherkit.php
@@ -4,7 +4,7 @@ return [
         'config' => [
             'jwt' => env('WEATHERKIT_JWT_TOKEN', ''),
 
-            'pathToKeyFile' => base_path(env('WEATHERKIT_KEY_PATH', '')),
+            'key' => base_path(env('WEATHERKIT_KEY', '')),
             'keyId' => env('WEATHERKIT_KEY_ID', ''),
             'teamId' => env('WEATHERKIT_TEAM_ID'),
             'bundleId' => env('WEATHERKIT_BUNDLE_ID'),

--- a/config/weatherkit.php
+++ b/config/weatherkit.php
@@ -4,7 +4,7 @@ return [
         'config' => [
             'jwt' => env('WEATHERKIT_JWT_TOKEN', ''),
 
-            'key' => base_path(env('WEATHERKIT_KEY', '')),
+            'key' => env('WEATHERKIT_KEY', ''),
             'keyId' => env('WEATHERKIT_KEY_ID', ''),
             'teamId' => env('WEATHERKIT_TEAM_ID'),
             'bundleId' => env('WEATHERKIT_BUNDLE_ID'),

--- a/src/JWTToken.php
+++ b/src/JWTToken.php
@@ -2,6 +2,7 @@
 namespace Rich2k\LaravelWeatherKit;
 
 use Firebase\JWT\JWT;
+use Illuminate\Support\Facades\Storage;
 use Rich2k\LaravelWeatherKit\Exceptions\KeyDecodingException;
 use Rich2k\LaravelWeatherKit\Exceptions\KeyFileMissingException;
 use Rich2k\LaravelWeatherKit\Exceptions\TokenGenerationFailedException;
@@ -34,7 +35,7 @@ class JWTToken
             $decodedKey = $this->decodeKeyString($keyValue);
         }
         else {
-            if (! file_exists($keyValue)) {
+            if (! Storage::exists($keyValue)) {
                 throw new KeyFileMissingException('Cannot find key in path ' . $keyValue);
             }
 
@@ -80,7 +81,7 @@ class JWTToken
      */
     protected function decodeKeyFile(string $p8KeyPath)
     {
-        $key = openssl_pkey_get_private(file_get_contents($p8KeyPath));
+        $key = openssl_pkey_get_private(Storage::get($p8KeyPath));
         if (! $key) {
             throw new KeyDecodingException('Key could not be decoded.');
         }

--- a/src/WeatherKit.php
+++ b/src/WeatherKit.php
@@ -43,7 +43,7 @@ class WeatherKit
         if (config('weatherkit.auth.type') === WeatherKit::AUTH_TYPE_P8) {
             try {
                 $this->jwtToken = new JWTToken(
-                    config('weatherkit.auth.config.pathToKeyFile'),
+                    config('weatherkit.auth.config.key'),
                     config('weatherkit.auth.config.keyId'),
                     config('weatherkit.auth.config.teamId'),
                     config('weatherkit.auth.config.bundleId'),

--- a/src/WeatherKit.php
+++ b/src/WeatherKit.php
@@ -1,343 +1,105 @@
 <?php
 namespace Rich2k\LaravelWeatherKit;
 
-use Carbon\Carbon;
-use Illuminate\Support\Collection;
-use Rich2k\LaravelWeatherKit\Exceptions\DataSetNotFoundException;
-use Rich2k\LaravelWeatherKit\Exceptions\LaravelWeatherKitException;
-use Rich2k\LaravelWeatherKit\Exceptions\KeyNotFoundExceptione;
-use Rich2k\LaravelWeatherKit\Exceptions\MissingCoordinatesException;
+use Firebase\JWT\JWT;
+use Illuminate\Support\Facades\Storage;
+use Rich2k\LaravelWeatherKit\Exceptions\KeyDecodingException;
+use Rich2k\LaravelWeatherKit\Exceptions\KeyFileMissingException;
 use Rich2k\LaravelWeatherKit\Exceptions\TokenGenerationFailedException;
+use Throwable;
 
-class WeatherKit
+/**
+ * JWTToken
+ *
+ * @package Rich2k\LaravelWeatherKit
+ */
+class JWTToken
 {
-    public const AUTH_TYPE_TOKEN = 'jwt';
-    public const AUTH_TYPE_P8 = 'p8';
-
-    protected $client;
-
-    protected $jwtToken;
-
-    protected $weatherEndpoint = 'https://weatherkit.apple.com/api/v1/weather';
-    protected $availabilityEndpoint = 'https://weatherkit.apple.com/api/v1/availability';
-
-    protected array $params = [];
-    protected array $dataSets = ['currentWeather', 'forecastDaily', 'forecastHourly', 'forecastNextHour'];
-    protected ?float $lat = null;
-    protected ?float $lon = null;
-    protected ?string $country = null;
-    protected ?string $lang = null;
-    protected ?Carbon $currentAsOf = null;
-    protected ?Carbon $hourlyStart = null;
-    protected ?Carbon $hourlyEnd = null;
-    protected ?Carbon $dailyStart = null;
-    protected ?Carbon $dailyEnd = null;
+    /**
+     * Generated JWT token
+     *
+     * @var string
+     */
+    protected string $jwtToken;
 
     /**
-     * WeatherKit constructor.
-     *
-     * @throws LaravelWeatherKitException
+     * @param string $keyValue
+     * @param string $keyId
+     * @param string $teamId
+     * @param string $appBundleId
+     * @param int $tokenTTL
      */
-    public function __construct()
+    public function __construct(string $keyValue, string $keyId, string $teamId, string $bundleId, int $tokenTTL)
     {
-        if (config('weatherkit.auth.type') === WeatherKit::AUTH_TYPE_P8) {
-            try {
-                $this->jwtToken = new JWTToken(
-                    config('weatherkit.auth.config.key'),
-                    config('weatherkit.auth.config.keyId'),
-                    config('weatherkit.auth.config.teamId'),
-                    config('weatherkit.auth.config.bundleId'),
-                    config('weatherkit.auth.config.tokenTTL')
-                );
-            } catch (TokenGenerationFailedException | KeyFileMissingException | TokenGenerationFailedException $e) {
-                throw new LaravelWeatherKitException($e->getMessage(), $e->getCode(), $e);
+        if (str_starts_with($keyValue, '-----BEGIN PRIVATE KEY-----')) {
+            $decodedKey = $this->decodeKeyString($keyValue);
+        }
+        else {
+            if (! Storage::exists($keyValue)) {
+                throw new KeyFileMissingException('Cannot find key in path ' . $keyValue);
             }
-        } else {
-            $this->jwtToken = config('weatherkit.auth.config.jwt');
+
+            $decodedKey = $this->decodeKeyFile($keyValue);
+
         }
 
-        $this->client = new \GuzzleHttp\Client();
-
-        $this->language(config('weatherkit.languageCode'));
-        $this->timezone(config('weatherkit.timezone'));
+        try {
+            $this->token = JWT::encode([
+                'iss' => $teamId,
+                'sub' => $bundleId,
+                'iat' => time(),
+                'exp' => time() + $tokenTTL,
+            ], $decodedKey, 'ES256' , $keyId, [
+                'id' => $teamId . '.' . $bundleId
+            ]);
+        } catch (Throwable $e) {
+            throw new TokenGenerationFailedException('Token failed to generate', 0, $e);
+        }
     }
 
     /**
-     * Sets the latitude and longitude. Must be set
+     * Get the generated JWT token
      *
-     * @param $lat
-     * @param $lon
-     * @return $this
+     * @return string
      */
-    public function location($lat, $lon)
+    public function getToken(): string
     {
-        $this->lat = $lat;
-        $this->lon = $lon;
-        return $this;
+        return $this->token;
     }
 
     /**
-     * @return Collection
-     * @throws MissingCoordinatesException
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @return string
      */
-    public function weather(): Collection
+    public function __toString(): string
     {
-        if (! $this->lat || ! $this->lon) {
-            throw new MissingCoordinatesException('Missing coordinates of either latitude or longitude.');
+        return $this->getToken();
+    }
+
+    /**
+     * @param string $p8KeyPath
+     * @return resource
+     */
+    protected function decodeKeyFile(string $p8KeyPath)
+    {
+        $key = openssl_pkey_get_private(Storage::get($p8KeyPath));
+        if (! $key) {
+            throw new KeyDecodingException('Key could not be decoded.');
         }
 
-        $url = $this->weatherEndpoint  . '/' . $this->lang . '/' . $this->lat . '/' . $this->lon;
-
-        $response = $this->client->get($url, [
-           'headers' => ['Authorization' => 'Bearer ' . $this->jwtToken],
-           'query' => $this->buildParams(),
-        ]);
-
-        return collect(json_decode($response->getBody()))->recursive();
+        return $key;
     }
 
     /**
-     * Builds the endpoint url and sends the get request
-     *
-     * @return Collection
-     * @throws MissingCoordinatesException
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @param string $p8KeyString
+     * @return resource
      */
-    public function availability(): Collection
+    protected function decodeKeyString(string $p8KeyString)
     {
-        if (! $this->lat || ! $this->lon) {
-            throw new MissingCoordinatesException('Missing coordinates of either latitude or longitude.');
+        $key = openssl_pkey_get_private($p8KeyString);
+        if (! $key) {
+            throw new KeyDecodingException('Key could not be decoded.');
         }
 
-        $url = $this->availabilityEndpoint  . '/' . $this->lat . '/' . $this->lon;
-
-        $response = $this->client->get($url, [
-            'headers' => ['Authorization' => 'Bearer ' . $this->jwtToken],
-            'query' => $this->buildParams(),
-        ]);
-
-        $this->dataSets = json_decode($response->getBody());
-
-        return collect($this->dataSets);
-    }
-
-    /**
-     * Sets the dataSets query parameter by taking an array
-     *
-     * @param array $dataSets
-     * @return $this
-     */
-    public function dataSets(array $dataSets): WeatherKit
-    {
-        $this->dataSets = $dataSets;
-        return $this;
-    }
-
-    /**
-     * The time to obtain current conditions. Defaults to now.
-     * See: https://developer.apple.com/documentation/weatherkitrestapi/get_api_v1_weather_language_latitude_longitude
-     *
-     * @param Carbon|null $asOf
-     * @return $this
-     */
-    public function currentAsOf(?Carbon $asOf): WeatherKit
-    {
-        $this->currentAsOf = $asOf;
-        return $this;
-    }
-
-    /**
-     * The time to start the hourly forecast. If this parameter is absent, hourly forecasts start on the current hour.
-     * See: https://developer.apple.com/documentation/weatherkitrestapi/get_api_v1_weather_language_latitude_longitude
-     *
-     * @param Carbon|null $hourlyStart
-     * @return $this
-     */
-    public function hourlyStart(?Carbon $hourlyStart): WeatherKit
-    {
-        $this->hourlyStart = $hourlyStart;
-        return $this;
-    }
-
-    /**
-     * The time to end the hourly forecast. If this parameter is absent, hourly forecasts run 24 hours or the length of the daily forecast, whichever is longer.
-     * See: https://developer.apple.com/documentation/weatherkitrestapi/get_api_v1_weather_language_latitude_longitude
-     *
-     * @param Carbon|null $hourlyEnd
-     * @return $this
-     */
-    public function hourlyEnd(?Carbon $hourlyEnd): WeatherKit
-    {
-        $this->hourlyEnd = $hourlyEnd;
-        return $this;
-    }
-
-    /**
-     * The time to start the daily forecast. If this parameter is absent, daily forecasts start on the current day.
-     * See: https://developer.apple.com/documentation/weatherkitrestapi/get_api_v1_weather_language_latitude_longitude
-     *
-     * @param Carbon|null $dailyStart
-     * @return $this
-     */
-    public function dailyStart(?Carbon $dailyStart): WeatherKit
-    {
-        $this->dailyStart = $dailyStart;
-        return $this;
-    }
-
-    /**
-     * The time to end the daily forecast. If this parameter is absent, daily forecasts run for 10 days.
-     * See: https://developer.apple.com/documentation/weatherkitrestapi/get_api_v1_weather_language_latitude_longitude
-     *
-     * @param Carbon|null $dailyEnd
-     * @return $this
-     */
-    public function dailyEnd(?Carbon $dailyEnd): WeatherKit
-    {
-        $this->dailyEnd = $dailyEnd;
-        return $this;
-    }
-
-    /**
-     * The name of the timezone to use for rolling up weather forecasts into daily forecasts.
-     * See: https://developer.apple.com/documentation/weatherkitrestapi/get_api_v1_weather_language_latitude_longitude
-     *
-     * @param string $timezone
-     * @return $this
-     */
-    public function timezone(string $timezone): WeatherKit
-    {
-        $this->timezone = $timezone;
-        return $this;
-    }
-
-    /**
-     * Sets the return language
-     *
-     * @param $lang
-     * @return $this
-     */
-    public function language(string $lang): WeatherKit
-    {
-        $this->lang = $lang;
-        return $this;
-    }
-
-    /**
-     * @param string $country
-     * @return $this
-     */
-    public function country(string $country): WeatherKit
-    {
-        $this->country = $country;
-        return $this;
-    }
-
-    ///////////////////////////////////////////////////////////////////
-    //////////////////////////// HELPERS //////////////////////////////
-    ///////////////////////////////////////////////////////////////////
-
-    /**
-     * Filters out metadata to get only currently
-     *
-     * @return Collection
-     * @throws DataSetNotFoundException
-     * @throws MissingCoordinatesException
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     */
-    public function currently(): Collection
-    {
-        return $this->getSingleDataSet('currentWeather');
-    }
-
-    /**
-     * Filters out metadata to get only hourly
-     *
-     * @return Collection
-     * @throws DataSetNotFoundException
-     * @throws MissingCoordinatesException
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     */
-    public function hourly(): Collection
-    {
-        return $this->getSingleDataSet('forecastHourly');
-    }
-
-    /**
-     * Filters out metadata to get only daily
-     *
-     * @return Collection
-     * @throws DataSetNotFoundException
-     * @throws MissingCoordinatesException
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     */
-    public function daily(): Collection
-    {
-        return $this->getSingleDataSet('forecastDaily');
-    }
-
-    /**
-     * Filters out metadata to get only next hour
-     *
-     * @return Collection
-     * @throws DataSetNotFoundException
-     * @throws MissingCoordinatesException
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     */
-    public function nextHour(): Collection
-    {
-        return $this->getSingleDataSet('forecastNextHour');
-    }
-
-    /**
-     * @param string $dataSet
-     * @return Collection
-     * @throws DataSetNotFoundException
-     * @throws MissingCoordinatesException
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     */
-    protected function getSingleDataSet(string $dataSet)
-    {
-        $response = $this->dataSets([$dataSet])->weather();
-
-        if (! $response->has($dataSet)) {
-            throw new DataSetNotFoundException($dataSet . ' data set not available for this location');
-        }
-
-        return $response->get($dataSet);
-    }
-
-    /**
-     * Build the query parameters
-     *
-     * @return array
-     */
-    protected function buildParams(): array
-    {
-        $this->params = [];
-        if ($this->dataSets) {
-            $this->params['dataSets'] = implode(',', $this->dataSets);
-        }
-        if ($this->timezone) {
-            $this->params['timezone'] = $this->timezone;
-        }
-        if ($this->currentAsOf) {
-            $this->params['currentAsOf'] = $this->currentAsOf->toIso8601ZuluString();
-        }
-        if ($this->dailyStart) {
-            $this->params['dailyStart'] = $this->dailyStart->toIso8601ZuluString();
-        }
-        if ($this->dailyEnd) {
-            $this->params['dailyEnd'] = $this->dailyEnd->toIso8601ZuluString();
-        }
-        if ($this->hourlyStart) {
-            $this->params['hourlyStart'] = $this->hourlyStart->toIso8601ZuluString();
-        }
-        if ($this->hourlyEnd) {
-            $this->params['hourlyEnd'] = $this->hourlyEnd->toIso8601ZuluString();
-        }
-
-        return $this->params;
+        return $key;
     }
 }

--- a/src/WeatherKit.php
+++ b/src/WeatherKit.php
@@ -1,105 +1,343 @@
 <?php
 namespace Rich2k\LaravelWeatherKit;
 
-use Firebase\JWT\JWT;
-use Illuminate\Support\Facades\Storage;
-use Rich2k\LaravelWeatherKit\Exceptions\KeyDecodingException;
-use Rich2k\LaravelWeatherKit\Exceptions\KeyFileMissingException;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Rich2k\LaravelWeatherKit\Exceptions\DataSetNotFoundException;
+use Rich2k\LaravelWeatherKit\Exceptions\LaravelWeatherKitException;
+use Rich2k\LaravelWeatherKit\Exceptions\KeyNotFoundExceptione;
+use Rich2k\LaravelWeatherKit\Exceptions\MissingCoordinatesException;
 use Rich2k\LaravelWeatherKit\Exceptions\TokenGenerationFailedException;
-use Throwable;
 
-/**
- * JWTToken
- *
- * @package Rich2k\LaravelWeatherKit
- */
-class JWTToken
+class WeatherKit
 {
-    /**
-     * Generated JWT token
-     *
-     * @var string
-     */
-    protected string $jwtToken;
+    public const AUTH_TYPE_TOKEN = 'jwt';
+    public const AUTH_TYPE_P8 = 'p8';
+
+    protected $client;
+
+    protected $jwtToken;
+
+    protected $weatherEndpoint = 'https://weatherkit.apple.com/api/v1/weather';
+    protected $availabilityEndpoint = 'https://weatherkit.apple.com/api/v1/availability';
+
+    protected array $params = [];
+    protected array $dataSets = ['currentWeather', 'forecastDaily', 'forecastHourly', 'forecastNextHour'];
+    protected ?float $lat = null;
+    protected ?float $lon = null;
+    protected ?string $country = null;
+    protected ?string $lang = null;
+    protected ?Carbon $currentAsOf = null;
+    protected ?Carbon $hourlyStart = null;
+    protected ?Carbon $hourlyEnd = null;
+    protected ?Carbon $dailyStart = null;
+    protected ?Carbon $dailyEnd = null;
 
     /**
-     * @param string $keyValue
-     * @param string $keyId
-     * @param string $teamId
-     * @param string $appBundleId
-     * @param int $tokenTTL
+     * WeatherKit constructor.
+     *
+     * @throws LaravelWeatherKitException
      */
-    public function __construct(string $keyValue, string $keyId, string $teamId, string $bundleId, int $tokenTTL)
+    public function __construct()
     {
-        if (str_starts_with($keyValue, '-----BEGIN PRIVATE KEY-----')) {
-            $decodedKey = $this->decodeKeyString($keyValue);
-        }
-        else {
-            if (! Storage::exists($keyValue)) {
-                throw new KeyFileMissingException('Cannot find key in path ' . $keyValue);
+        if (config('weatherkit.auth.type') === WeatherKit::AUTH_TYPE_P8) {
+            try {
+                $this->jwtToken = new JWTToken(
+                    config('weatherkit.auth.config.pathToKeyFile'),
+                    config('weatherkit.auth.config.keyId'),
+                    config('weatherkit.auth.config.teamId'),
+                    config('weatherkit.auth.config.bundleId'),
+                    config('weatherkit.auth.config.tokenTTL')
+                );
+            } catch (TokenGenerationFailedException | KeyFileMissingException | TokenGenerationFailedException $e) {
+                throw new LaravelWeatherKitException($e->getMessage(), $e->getCode(), $e);
             }
-
-            $decodedKey = $this->decodeKeyFile($keyValue);
-
+        } else {
+            $this->jwtToken = config('weatherkit.auth.config.jwt');
         }
 
-        try {
-            $this->token = JWT::encode([
-                'iss' => $teamId,
-                'sub' => $bundleId,
-                'iat' => time(),
-                'exp' => time() + $tokenTTL,
-            ], $decodedKey, 'ES256' , $keyId, [
-                'id' => $teamId . '.' . $bundleId
-            ]);
-        } catch (Throwable $e) {
-            throw new TokenGenerationFailedException('Token failed to generate', 0, $e);
-        }
+        $this->client = new \GuzzleHttp\Client();
+
+        $this->language(config('weatherkit.languageCode'));
+        $this->timezone(config('weatherkit.timezone'));
     }
 
     /**
-     * Get the generated JWT token
+     * Sets the latitude and longitude. Must be set
      *
-     * @return string
+     * @param $lat
+     * @param $lon
+     * @return $this
      */
-    public function getToken(): string
+    public function location($lat, $lon)
     {
-        return $this->token;
+        $this->lat = $lat;
+        $this->lon = $lon;
+        return $this;
     }
 
     /**
-     * @return string
+     * @return Collection
+     * @throws MissingCoordinatesException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function __toString(): string
+    public function weather(): Collection
     {
-        return $this->getToken();
-    }
-
-    /**
-     * @param string $p8KeyPath
-     * @return resource
-     */
-    protected function decodeKeyFile(string $p8KeyPath)
-    {
-        $key = openssl_pkey_get_private(Storage::get($p8KeyPath));
-        if (! $key) {
-            throw new KeyDecodingException('Key could not be decoded.');
+        if (! $this->lat || ! $this->lon) {
+            throw new MissingCoordinatesException('Missing coordinates of either latitude or longitude.');
         }
 
-        return $key;
+        $url = $this->weatherEndpoint  . '/' . $this->lang . '/' . $this->lat . '/' . $this->lon;
+
+        $response = $this->client->get($url, [
+           'headers' => ['Authorization' => 'Bearer ' . $this->jwtToken],
+           'query' => $this->buildParams(),
+        ]);
+
+        return collect(json_decode($response->getBody()))->recursive();
     }
 
     /**
-     * @param string $p8KeyString
-     * @return resource
+     * Builds the endpoint url and sends the get request
+     *
+     * @return Collection
+     * @throws MissingCoordinatesException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    protected function decodeKeyString(string $p8KeyString)
+    public function availability(): Collection
     {
-        $key = openssl_pkey_get_private($p8KeyString);
-        if (! $key) {
-            throw new KeyDecodingException('Key could not be decoded.');
+        if (! $this->lat || ! $this->lon) {
+            throw new MissingCoordinatesException('Missing coordinates of either latitude or longitude.');
         }
 
-        return $key;
+        $url = $this->availabilityEndpoint  . '/' . $this->lat . '/' . $this->lon;
+
+        $response = $this->client->get($url, [
+            'headers' => ['Authorization' => 'Bearer ' . $this->jwtToken],
+            'query' => $this->buildParams(),
+        ]);
+
+        $this->dataSets = json_decode($response->getBody());
+
+        return collect($this->dataSets);
+    }
+
+    /**
+     * Sets the dataSets query parameter by taking an array
+     *
+     * @param array $dataSets
+     * @return $this
+     */
+    public function dataSets(array $dataSets): WeatherKit
+    {
+        $this->dataSets = $dataSets;
+        return $this;
+    }
+
+    /**
+     * The time to obtain current conditions. Defaults to now.
+     * See: https://developer.apple.com/documentation/weatherkitrestapi/get_api_v1_weather_language_latitude_longitude
+     *
+     * @param Carbon|null $asOf
+     * @return $this
+     */
+    public function currentAsOf(?Carbon $asOf): WeatherKit
+    {
+        $this->currentAsOf = $asOf;
+        return $this;
+    }
+
+    /**
+     * The time to start the hourly forecast. If this parameter is absent, hourly forecasts start on the current hour.
+     * See: https://developer.apple.com/documentation/weatherkitrestapi/get_api_v1_weather_language_latitude_longitude
+     *
+     * @param Carbon|null $hourlyStart
+     * @return $this
+     */
+    public function hourlyStart(?Carbon $hourlyStart): WeatherKit
+    {
+        $this->hourlyStart = $hourlyStart;
+        return $this;
+    }
+
+    /**
+     * The time to end the hourly forecast. If this parameter is absent, hourly forecasts run 24 hours or the length of the daily forecast, whichever is longer.
+     * See: https://developer.apple.com/documentation/weatherkitrestapi/get_api_v1_weather_language_latitude_longitude
+     *
+     * @param Carbon|null $hourlyEnd
+     * @return $this
+     */
+    public function hourlyEnd(?Carbon $hourlyEnd): WeatherKit
+    {
+        $this->hourlyEnd = $hourlyEnd;
+        return $this;
+    }
+
+    /**
+     * The time to start the daily forecast. If this parameter is absent, daily forecasts start on the current day.
+     * See: https://developer.apple.com/documentation/weatherkitrestapi/get_api_v1_weather_language_latitude_longitude
+     *
+     * @param Carbon|null $dailyStart
+     * @return $this
+     */
+    public function dailyStart(?Carbon $dailyStart): WeatherKit
+    {
+        $this->dailyStart = $dailyStart;
+        return $this;
+    }
+
+    /**
+     * The time to end the daily forecast. If this parameter is absent, daily forecasts run for 10 days.
+     * See: https://developer.apple.com/documentation/weatherkitrestapi/get_api_v1_weather_language_latitude_longitude
+     *
+     * @param Carbon|null $dailyEnd
+     * @return $this
+     */
+    public function dailyEnd(?Carbon $dailyEnd): WeatherKit
+    {
+        $this->dailyEnd = $dailyEnd;
+        return $this;
+    }
+
+    /**
+     * The name of the timezone to use for rolling up weather forecasts into daily forecasts.
+     * See: https://developer.apple.com/documentation/weatherkitrestapi/get_api_v1_weather_language_latitude_longitude
+     *
+     * @param string $timezone
+     * @return $this
+     */
+    public function timezone(string $timezone): WeatherKit
+    {
+        $this->timezone = $timezone;
+        return $this;
+    }
+
+    /**
+     * Sets the return language
+     *
+     * @param $lang
+     * @return $this
+     */
+    public function language(string $lang): WeatherKit
+    {
+        $this->lang = $lang;
+        return $this;
+    }
+
+    /**
+     * @param string $country
+     * @return $this
+     */
+    public function country(string $country): WeatherKit
+    {
+        $this->country = $country;
+        return $this;
+    }
+
+    ///////////////////////////////////////////////////////////////////
+    //////////////////////////// HELPERS //////////////////////////////
+    ///////////////////////////////////////////////////////////////////
+
+    /**
+     * Filters out metadata to get only currently
+     *
+     * @return Collection
+     * @throws DataSetNotFoundException
+     * @throws MissingCoordinatesException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function currently(): Collection
+    {
+        return $this->getSingleDataSet('currentWeather');
+    }
+
+    /**
+     * Filters out metadata to get only hourly
+     *
+     * @return Collection
+     * @throws DataSetNotFoundException
+     * @throws MissingCoordinatesException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function hourly(): Collection
+    {
+        return $this->getSingleDataSet('forecastHourly');
+    }
+
+    /**
+     * Filters out metadata to get only daily
+     *
+     * @return Collection
+     * @throws DataSetNotFoundException
+     * @throws MissingCoordinatesException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function daily(): Collection
+    {
+        return $this->getSingleDataSet('forecastDaily');
+    }
+
+    /**
+     * Filters out metadata to get only next hour
+     *
+     * @return Collection
+     * @throws DataSetNotFoundException
+     * @throws MissingCoordinatesException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function nextHour(): Collection
+    {
+        return $this->getSingleDataSet('forecastNextHour');
+    }
+
+    /**
+     * @param string $dataSet
+     * @return Collection
+     * @throws DataSetNotFoundException
+     * @throws MissingCoordinatesException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    protected function getSingleDataSet(string $dataSet)
+    {
+        $response = $this->dataSets([$dataSet])->weather();
+
+        if (! $response->has($dataSet)) {
+            throw new DataSetNotFoundException($dataSet . ' data set not available for this location');
+        }
+
+        return $response->get($dataSet);
+    }
+
+    /**
+     * Build the query parameters
+     *
+     * @return array
+     */
+    protected function buildParams(): array
+    {
+        $this->params = [];
+        if ($this->dataSets) {
+            $this->params['dataSets'] = implode(',', $this->dataSets);
+        }
+        if ($this->timezone) {
+            $this->params['timezone'] = $this->timezone;
+        }
+        if ($this->currentAsOf) {
+            $this->params['currentAsOf'] = $this->currentAsOf->toIso8601ZuluString();
+        }
+        if ($this->dailyStart) {
+            $this->params['dailyStart'] = $this->dailyStart->toIso8601ZuluString();
+        }
+        if ($this->dailyEnd) {
+            $this->params['dailyEnd'] = $this->dailyEnd->toIso8601ZuluString();
+        }
+        if ($this->hourlyStart) {
+            $this->params['hourlyStart'] = $this->hourlyStart->toIso8601ZuluString();
+        }
+        if ($this->hourlyEnd) {
+            $this->params['hourlyEnd'] = $this->hourlyEnd->toIso8601ZuluString();
+        }
+
+        return $this->params;
     }
 }


### PR DESCRIPTION
Added the ability to use recommended methods for storing private keys outside code repositories.

Changed env WEATHERKIT_KEY_PATH to WEATHERKIT_KEY.

This value can either be set to the private key or a path to the private key.

src/JWTToken.php now checks to see if keyValue starts with -----BEGIN PRIVATE KEY-----. If it does, we decode that value, else we check for file existence or throw an error.

Also, updated code to utilize the Storage:: facade to allow for cloud storage options on Laravel Vapor.