### PR TITLE
Add support for Weather Alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This provides a Laravel style wrapper for Apple's WeatherKit api, which replaced
 
 For more information see https://developer.apple.com/weatherkit/get-started/
 
-Please note, Apple requires attribution to use this API in your code https://developer.apple.com/weatherkit/get-started/#attribution-requirements and up to 500,000 calls/month are included with your apple developer account membership.
+Please note, Apple requires attribution to use this API in your code https://developer.apple.com/weatherkit/get-started/#attribution-requirements and up to 500,000 calls/month are included with your apple developer account membership. See [Attribution](#Attribution) section below for a helper function.
 
 ## Install
 
@@ -207,6 +207,16 @@ Specify which data sets to use to reduce data transfer.
 
 By default we will try to call `'currentWeather', 'forecastDaily', 'forecastHourly', 'forecastNextHour'`, however you can set these manually with `dataSets()` function. You can also dynamically set this by calling `availability()` before `weather()` when not using through a facade.
 
+Available data sets, currently supported
+
+* `currentWeather`
+* `forecastDaily`
+* `forecastHourly`
+* `forecastNextHour`
+* `weatherAlerts`
+
+Note, if you call `weather()` without defining your data sets, we will not automatically include `weatherAlerts`, as `weatherAlerts` also requires you to set your `country('GB')` using an ISO Alpha-2 country code
+
 ```php
 WeatherKit::location(lat, lon)->dataSets(['currentWeather', 'forecastDaily'])->weather();
 
@@ -247,6 +257,13 @@ The name of the timezone to use for rolling up weather forecasts into daily fore
 WeatherKit::location(lat, lon)->timezone('Americas/Los_Angeles')->weather();
 ```
 
+#### country(countyCode)
+This is the ISO 3166-1 alpha-2 two character country code. This parameter is required for weather alerts. The WeatherKit API requires the country code to be uppercase, this library will handle this for you.
+
+``` php
+WeatherKit::location(lat, lon)->country(country)->alerts();
+```
+
 ### Helpers
 The following are shorthand helpers to add readability equivalent to using `dataSets` set to a single object.
 ```php
@@ -254,11 +271,20 @@ The following are shorthand helpers to add readability equivalent to using `data
 ->hourly()
 ->daily()
 ->nextHour()
+->alerts()
 ```
 For example, these two statements are the same
 ```php
 WeatherKit::location(lat, lon)->hourly()
 WeatherKit::location(lat, lon)->dataSets(['forecastHourly'])->weather()->get('forecastHourly')
+```
+
+### Attribution
+
+Use of the WeatherKit REST API requires attribution. You can obtain the attribution logos and source by calling the `attribution()` helper. The language is required for this helper.
+
+```php
+WeatherKit::language('en')->attribution()
 ```
 
 ## License

--- a/src/Exceptions/MissingRequiredParametersException.php
+++ b/src/Exceptions/MissingRequiredParametersException.php
@@ -1,0 +1,11 @@
+<?php
+namespace Rich2k\LaravelWeatherKit\Exceptions;
+
+/**
+ * Class MissingRequiredParametersException
+ *
+ * @package Rich2k\LaravelWeatherKit\Exceptions
+ */
+class MissingRequiredParametersException extends LaravelWeatherKitException
+{
+}

--- a/src/Facades/WeatherKit.php
+++ b/src/Facades/WeatherKit.php
@@ -22,6 +22,8 @@ use Illuminate\Support\Facades\Facade;
  * @method static Collection hourly()
  * @method static Collection daily()
  * @method static Collection nextHour()
+ * @method static Collection alerts()
+ * @method static Collection attribution()
  */
 class WeatherKit extends Facade
 {

--- a/src/WeatherKit.php
+++ b/src/WeatherKit.php
@@ -2,11 +2,13 @@
 namespace Rich2k\LaravelWeatherKit;
 
 use Carbon\Carbon;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Collection;
 use Rich2k\LaravelWeatherKit\Exceptions\DataSetNotFoundException;
 use Rich2k\LaravelWeatherKit\Exceptions\KeyFileMissingException;
 use Rich2k\LaravelWeatherKit\Exceptions\LaravelWeatherKitException;
 use Rich2k\LaravelWeatherKit\Exceptions\MissingCoordinatesException;
+use Rich2k\LaravelWeatherKit\Exceptions\MissingRequiredParametersException;
 use Rich2k\LaravelWeatherKit\Exceptions\TokenGenerationFailedException;
 
 class WeatherKit
@@ -20,8 +22,10 @@ class WeatherKit
 
     protected $weatherEndpoint = 'https://weatherkit.apple.com/api/v1/weather';
     protected $availabilityEndpoint = 'https://weatherkit.apple.com/api/v1/availability';
+    protected $attributionEndpoint = 'https://weatherkit.apple.com/attribution';
 
     protected array $params = [];
+
     protected array $dataSets = ['currentWeather', 'forecastDaily', 'forecastHourly', 'forecastNextHour'];
     protected ?float $lat = null;
     protected ?float $lon = null;
@@ -226,12 +230,14 @@ class WeatherKit
     }
 
     /**
+     * The country code, should be a valid two character ISO 3166-1 alpha-2 country code
+     *
      * @param string $country
      * @return $this
      */
     public function country(string $country): WeatherKit
     {
-        $this->country = $country;
+        $this->country = strtoupper($country);
         return $this;
     }
 
@@ -292,6 +298,42 @@ class WeatherKit
     }
 
     /**
+     * @throws MissingCoordinatesException
+     * @throws MissingRequiredParametersException
+     * @throws DataSetNotFoundException
+     * @throws GuzzleException
+     */
+    public function alerts(): Collection
+    {
+        if (! $this->country) {
+            throw new MissingRequiredParametersException('Country param is required for alert data');
+        }
+
+        return $this->getSingleDataSet('weatherAlerts');
+    }
+
+    /**
+     * @return Collection
+     * @throws GuzzleException
+     * @throws MissingRequiredParametersException
+     */
+    public function attribution(): Collection
+    {
+        if (! $this->lang) {
+            throw new MissingRequiredParametersException('Language param is required for attribution data');
+        }
+
+        $url = $this->attributionEndpoint  . '/' . $this->lang;
+
+        $response = $this->client->get($url, [
+            'headers' => ['Authorization' => 'Bearer ' . $this->jwtToken],
+            'query' => $this->buildParams(),
+        ]);
+
+        return collect(json_decode($response->getBody()));
+    }
+
+    /**
      * @param string $dataSet
      * @return Collection
      * @throws DataSetNotFoundException
@@ -337,6 +379,9 @@ class WeatherKit
         }
         if ($this->hourlyEnd) {
             $this->params['hourlyEnd'] = $this->hourlyEnd->toIso8601ZuluString();
+        }
+        if ($this->country) {
+            $this->params['country'] = $this->country;
         }
 
         return $this->params;


### PR DESCRIPTION
Alerts api endpoint requires country as an ISO 3166-1 alpha-2 country code e.g. 'US', 'GB', etc

``` php
WeatherKit::country(country)->alerts();
```

Also added support for the attributions API endpoint

```php
WeatherKit::language('en')->attribution()
```

